### PR TITLE
Fix broken bits

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flavour_saver (0.3.6)
+    flavour_saver (0.5.0.pre.dokio)
       rltk (~> 2.2.0)
       tilt
 
@@ -77,3 +77,6 @@ DEPENDENCIES
   rspec-core
   rspec-expectations
   rspec-mocks
+
+BUNDLED WITH
+   1.17.3

--- a/lib/flavour_saver/helpers.rb
+++ b/lib/flavour_saver/helpers.rb
@@ -1,4 +1,5 @@
 require 'delegate'
+require 'ostruct'
 
 module FlavourSaver
   module Helpers
@@ -126,4 +127,3 @@ module FlavourSaver
 
   end
 end
-

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -6,7 +6,7 @@ module FlavourSaver
 
     # DEFAULT
 
-    rule /{{{/, :default do
+    rule /{{{\s*/, :default do
       push_state :expression
       :TEXPRST
     end
@@ -30,7 +30,7 @@ module FlavourSaver
       :EXPRSTFWSL
     end
 
-    rule /{{&/, :default do
+    rule /{{&\s*/, :default do
       push_state :expression
       :EXPRSTAMP
     end
@@ -40,7 +40,7 @@ module FlavourSaver
       :EXPRSTGT
     end
 
-    rule /{{/, :default do
+    rule /{{\s*/, :default do
       push_state :expression
       :EXPRST
     end
@@ -51,7 +51,7 @@ module FlavourSaver
 
     # EXPRESSION
 
-    rule /}}}/, :expression do
+    rule /\s*}}}/, :expression do
       pop_state
       :TEXPRE
     end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -89,12 +89,24 @@ module FlavourSaver
       :EQ
     end
 
+    rule /""/, :expression do # special rule because empty doesn't trigger token otherwise
+      [ :STRING, '' ]
+    end
+
     rule /"/, :expression do
       push_state :string
     end
 
+    rule /''/, :expression do # special rule because empty doesn't trigger token otherwise
+      [ :S_STRING, '' ]
+    end
+
     rule /'/, :expression do
       push_state :s_string
+    end
+
+    rule /\[\]/, :expression do # special rule because empty doesn't trigger token otherwise
+      [ :LITERAL, '' ]
     end
 
     rule /\[/, :expression do
@@ -141,7 +153,7 @@ module FlavourSaver
       pop_state
     end
 
-    rule /(\\"|[^"])*/, :string do |str|
+    rule /(\\"|[^"])+/, :string do |str|
       [ :STRING, str ]
     end
 
@@ -151,7 +163,7 @@ module FlavourSaver
       pop_state
     end
 
-    rule /(\\'|[^'])*/, :s_string do |str|
+    rule /(\\'|[^'])+/, :s_string do |str|
       [ :S_STRING, str ]
     end
 
@@ -161,7 +173,7 @@ module FlavourSaver
       pop_state
     end
 
-    rule /([^\]]+)/, :segment_literal do |l|
+    rule /[^\]]+/, :segment_literal do |l|
       [ :LITERAL, l ]
     end
   end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -11,6 +11,10 @@ module FlavourSaver
       :TEXPRST
     end
 
+    rule /{{!/, :default do
+      push_state :comment
+    end
+
     rule /{{/, :default do
       push_state :expression
       :EXPRST
@@ -68,11 +72,6 @@ module FlavourSaver
       :EQ
     end
 
-    rule /\!/, :expression do
-      push_state :comment
-      :BANG
-    end
-
     rule /"/, :expression do
       push_state :string
     end
@@ -115,8 +114,11 @@ module FlavourSaver
 
     # COMMENT
 
-    rule /([^}}]*)/, :comment do |comment|
+    rule /}}/, :comment do
       pop_state
+    end
+
+    rule /[^}]+|}/m, :comment do |comment|
       [ :COMMENT, comment ]
     end
 

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -2,7 +2,6 @@ require 'rltk'
 
 module FlavourSaver
   class Lexer < RLTK::Lexer
-
     rule /{{{/, :default do
       push_state :expression
       :TEXPRST
@@ -133,7 +132,7 @@ module FlavourSaver
       :EXPRE
     end
 
-    rule /.*?(?={{|\z)/m, :default do |output|
+    rule /[^{]+|{/m, :default do |output|
       [ :OUT, output ]
     end
   end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -2,6 +2,8 @@ require 'rltk'
 
 module FlavourSaver
   class Lexer < RLTK::Lexer
+    # DEFAULT
+
     rule /{{{/, :default do
       push_state :expression
       :TEXPRST
@@ -11,6 +13,12 @@ module FlavourSaver
       push_state :expression
       :EXPRST
     end
+
+    rule /[^{]+|{/m, :default do |output|
+      [ :OUT, output ]
+    end
+
+    # EXPRESSION
 
     rule /#/, :expression do
       :HASH
@@ -53,11 +61,6 @@ module FlavourSaver
       :BANG
     end
 
-    rule /([^}}]*)/, :comment do |comment|
-      pop_state
-      [ :COMMENT, comment ]
-    end
-
     rule /else/, :expression do
       :ELSE
     end
@@ -74,24 +77,8 @@ module FlavourSaver
       push_state :string
     end
 
-    rule /(\\"|[^"])*/, :string do |str|
-      [ :STRING, str ]
-    end
-
-    rule /"/, :string do
-      pop_state
-    end
-
     rule /'/, :expression do
       push_state :s_string
-    end
-
-    rule /(\\'|[^'])*/, :s_string do |str|
-      [ :S_STRING, str ]
-    end
-
-    rule /'/, :s_string do
-      pop_state
     end
 
     rule /[A-Za-z_\-][A-Za-z0-9_\-]*/, :expression do |name|
@@ -110,14 +97,6 @@ module FlavourSaver
       push_state :segment_literal
     end
 
-    rule /([^\]]+)/, :segment_literal do |l|
-      [ :LITERAL, l ]
-    end
-
-    rule /]/, :segment_literal do
-      pop_state
-    end
-
     rule /\s+/, :expression do
       :WHITE
     end
@@ -132,8 +111,41 @@ module FlavourSaver
       :EXPRE
     end
 
-    rule /[^{]+|{/m, :default do |output|
-      [ :OUT, output ]
+    # COMMENT
+
+    rule /([^}}]*)/, :comment do |comment|
+      pop_state
+      [ :COMMENT, comment ]
+    end
+
+    # STRING
+
+    rule /(\\"|[^"])*/, :string do |str|
+      [ :STRING, str ]
+    end
+
+    rule /"/, :string do
+      pop_state
+    end
+
+    # SINGLE-QUOTED STRING
+
+    rule /(\\'|[^'])*/, :s_string do |str|
+      [ :S_STRING, str ]
+    end
+
+    rule /'/, :s_string do
+      pop_state
+    end
+
+    # SEGMENT LITERAL
+
+    rule /([^\]]+)/, :segment_literal do |l|
+      [ :LITERAL, l ]
+    end
+
+    rule /]/, :segment_literal do
+      pop_state
     end
   end
 end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -6,6 +6,10 @@ module FlavourSaver
 
     # DEFAULT
 
+    rule /{{\s*(else|\^)\s*}}/, :default do
+      :EXPRELSE
+    end
+
     rule /{{{\s*/, :default do
       push_state :expression
       :TEXPRST

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -15,6 +15,31 @@ module FlavourSaver
       push_state :comment
     end
 
+    rule /{{#/, :default do
+      push_state :expression
+      :EXPRSTHASH
+    end
+
+    rule /{{\^/, :default do
+      push_state :expression
+      :EXPRSTHAT
+    end
+
+    rule /{{\//, :default do
+      push_state :expression
+      :EXPRSTFWSL
+    end
+
+    rule /{{&/, :default do
+      push_state :expression
+      :EXPRSTAMP
+    end
+
+    rule /{{\s*>/, :default do # the original FlavourSaver allows a space between {{ and > so this regex does too
+      push_state :expression
+      :EXPRSTGT
+    end
+
     rule /{{/, :default do
       push_state :expression
       :EXPRST
@@ -48,28 +73,12 @@ module FlavourSaver
       :DOTDOT
     end
 
-    rule /#/, :expression do
-      :HASH
-    end
-
     rule /\//, :expression do
       :FWSL
     end
 
-    rule /&/, :expression do
-      :AMP
-    end
-
-    rule /\^/, :expression do
-      :HAT
-    end
-
     rule /@/, :expression do
       :AT
-    end
-
-    rule />/, :expression do
-      :GT
     end
 
     rule /\./, :expression do

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -73,10 +73,6 @@ module FlavourSaver
       :DOTDOTSLASH
     end
 
-    rule /\.\./, :expression do
-      :DOTDOT
-    end
-
     rule /\//, :expression do
       :FWSL
     end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -63,10 +63,6 @@ module FlavourSaver
       :ELSE
     end
 
-    rule /([a-zA-Z0-9_-]*)/, :expression do |name|
-      [ :IDENT, name ]
-    end
-
     rule /\./, :expression do
       :DOT
     end
@@ -99,11 +95,16 @@ module FlavourSaver
       pop_state
     end
 
-    # Handlebars allows methods with hyphens in them. Ruby doesn't, so
-    # we'll assume you're trying to index the context with the identifier
-    # and call the result.
-    rule /([A-Za-z][a-z0-9_-]*[a-z0-9])/, :expression do |str|
-      [ :LITERAL, str ]
+    rule /[A-Za-z_\-][A-Za-z0-9_\-]*/, :expression do |name|
+      # Handlebars allows methods with hyphens in them. Ruby doesn't, so
+      # we'll assume you're trying to index the context with the identifier
+      # and call the result.
+
+      if name.include?('-')
+        [ :LITERAL, name ]
+      else
+        [ :IDENT, name ]
+      end
     end
 
     rule /\[/, :expression do

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -122,15 +122,8 @@ module FlavourSaver
     end
 
     rule /[A-Za-z_\-][A-Za-z0-9_\-]*/, :expression do |name|
-      # Handlebars allows methods with hyphens in them. Ruby doesn't, so
-      # we'll assume you're trying to index the context with the identifier
-      # and call the result.
-
-      if name.include?('-')
-        [ :LITERAL, name ]
-      else
-        [ :IDENT, name ]
-      end
+      # this is a divergence from FlavourSaver by Dokio -- even the dashed things are treated as methods
+      [ :IDENT, name ]
     end
 
     rule /([1-9][0-9]*(\.[0-9]+)?)/, :expression do |n|

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -56,7 +56,7 @@ module FlavourSaver
       :TEXPRE
     end
 
-    rule /}}/, :expression do
+    rule /\s*}}/, :expression do
       pop_state
       :EXPRE
     end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -20,7 +20,7 @@ module FlavourSaver
       :EXPRST
     end
 
-    rule /[^{]+|{/m, :default do |output|
+    rule /([^{]|{(?!{))+/m, :default do |output|
       [ :OUT, output ]
     end
 
@@ -126,7 +126,7 @@ module FlavourSaver
       pop_state
     end
 
-    rule /[^}]+|}/m, :comment do |comment|
+    rule /([^}]|}(?!}))+/m, :comment do |comment|
       [ :COMMENT, comment ]
     end
 

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -19,17 +19,17 @@ module FlavourSaver
       push_state :comment
     end
 
-    rule /{{#/, :default do
+    rule /{{#\s*/, :default do
       push_state :expression
       :EXPRSTHASH
     end
 
-    rule /{{\^/, :default do
+    rule /{{\^\s*/, :default do
       push_state :expression
       :EXPRSTHAT
     end
 
-    rule /{{\//, :default do
+    rule /{{\/\s*/, :default do
       push_state :expression
       :EXPRSTFWSL
     end
@@ -39,7 +39,7 @@ module FlavourSaver
       :EXPRSTAMP
     end
 
-    rule /{{\s*>/, :default do # the original FlavourSaver allows a space between {{ and > so this regex does too
+    rule /{{\s*>\s*/, :default do # the original FlavourSaver allows a space between {{ and > so this regex does too
       push_state :expression
       :EXPRSTGT
     end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -40,6 +40,14 @@ module FlavourSaver
       :WHITE
     end
 
+    rule /\.\.\//, :expression do
+      :DOTDOTSLASH
+    end
+
+    rule /\.\./, :expression do
+      :DOTDOT
+    end
+
     rule /#/, :expression do
       :HASH
     end

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -109,10 +109,6 @@ module FlavourSaver
       [ :BOOL, false ]
     end
 
-    rule /else/, :expression do
-      :ELSE
-    end
-
     rule /[A-Za-z_\-][A-Za-z0-9_\-]*/, :expression do |name|
       # Handlebars allows methods with hyphens in them. Ruby doesn't, so
       # we'll assume you're trying to index the context with the identifier

--- a/lib/flavour_saver/nodes.rb
+++ b/lib/flavour_saver/nodes.rb
@@ -95,7 +95,7 @@ module FlavourSaver
   end
 
   class ParentCallNode < CallNode
-    value :depth, Fixnum
+    value :depth, Integer
 
     def to_callnode
       CallNode.new(name,arguments)

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -60,7 +60,7 @@ module FlavourSaver
     end
 
     production(:expr_else) do
-      clause('EXPRST WHITE? ELSE EXPRE') { |_,_,_,_| }
+      clause('EXPRST ELSE EXPRE') { |_,_,_| }
       clause('EXPRSTHAT EXPRE') { |_,_| }
     end
 
@@ -88,8 +88,8 @@ module FlavourSaver
     end
 
     production(:expression_contents) do
-      clause('WHITE? call WHITE?') { |_,e,_| e }
-      clause('WHITE? local WHITE?') { |_,e,_| [e] }
+      clause('call') { |e| e }
+      clause('local') { |e| [e] }
     end
 
     production(:call) do

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -46,10 +46,10 @@ module FlavourSaver
     end
 
     production(:partial) do
-      clause('EXPRSTGT WHITE? STRING WHITE? EXPRE') { |_,_,e,_,_| PartialNode.new(e,[]) }
-      clause('EXPRSTGT WHITE? ident_or_literal WHITE? EXPRE') { |_,_,e,_,_| PartialNode.new(e,[]) }
-      clause('EXPRSTGT WHITE? ident_or_literal WHITE? call WHITE? EXPRE') { |_,_,e0,_,e1,_,_| PartialNode.new(e0,e1,nil) }
-      clause('EXPRSTGT WHITE? ident_or_literal WHITE? lit WHITE? EXPRE') { |_,_,e0,_,e1,_,_| PartialNode.new(e0,[],e1) }
+      clause('EXPRSTGT WHITE? STRING EXPRE') { |_,_,e,_| PartialNode.new(e,[]) }
+      clause('EXPRSTGT WHITE? ident_or_literal EXPRE') { |_,_,e,_| PartialNode.new(e,[]) }
+      clause('EXPRSTGT WHITE? ident_or_literal WHITE? call EXPRE') { |_,_,e0,_,e1,_| PartialNode.new(e0,e1,nil) }
+      clause('EXPRSTGT WHITE? ident_or_literal WHITE? lit EXPRE') { |_,_,e0,_,e1,_| PartialNode.new(e0,[],e1) }
     end
 
     production(:block_expression) do
@@ -60,8 +60,8 @@ module FlavourSaver
     end
 
     production(:expr_else) do
-      clause('EXPRST WHITE? ELSE WHITE? EXPRE') { |_,_,_,_,_| }
-      clause('EXPRSTHAT WHITE? EXPRE') { |_,_,_| }
+      clause('EXPRST WHITE? ELSE EXPRE') { |_,_,_,_| }
+      clause('EXPRSTHAT EXPRE') { |_,_| }
     end
 
     production(:expr) do
@@ -74,17 +74,17 @@ module FlavourSaver
     end
 
     production(:expr_bl_start) do
-      clause('EXPRSTHASH WHITE? IDENT WHITE? EXPRE') { |_,_,e,_,_| push_block CallNode.new(e,[]) }
-      clause('EXPRSTHASH WHITE? IDENT WHITE arguments WHITE? EXPRE') { |_,_,e,_,a,_,_| push_block CallNode.new(e,a) }
+      clause('EXPRSTHASH WHITE? IDENT EXPRE') { |_,_,e,_| push_block CallNode.new(e,[]) }
+      clause('EXPRSTHASH WHITE? IDENT WHITE arguments EXPRE') { |_,_,e,_,a,_| push_block CallNode.new(e,a) }
     end
 
     production(:expr_bl_inv_start) do
-      clause('EXPRSTHAT WHITE? IDENT WHITE? EXPRE') { |_,_,e,_,_| push_block CallNode.new(e,[]) }
-      clause('EXPRSTHAT WHITE? IDENT WHITE arguments WHITE? EXPRE') { |_,_,e,_,a,_,_| push_block CallNode.new(e,a) }
+      clause('EXPRSTHAT WHITE? IDENT EXPRE') { |_,_,e,_| push_block CallNode.new(e,[]) }
+      clause('EXPRSTHAT WHITE? IDENT WHITE arguments EXPRE') { |_,_,e,_,a,_| push_block CallNode.new(e,a) }
     end
 
     production(:expr_bl_end) do
-      clause('EXPRSTFWSL WHITE? IDENT WHITE? EXPRE') { |_,_,e,_,_| pop_block CallNode.new(e,[]) }
+      clause('EXPRSTFWSL WHITE? IDENT EXPRE') { |_,_,e,_| pop_block CallNode.new(e,[]) }
     end
 
     production(:expression_contents) do

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -41,6 +41,7 @@ module FlavourSaver
     production(:template_item) do
       clause('output') { |e| e }
       clause('expression') { |e| e }
+      clause('COMMENT') { |e| CommentNode.new(e) }
     end
 
     production(:output) do
@@ -50,7 +51,6 @@ module FlavourSaver
     production(:expression) do
       clause('block_expression') { |e| e }
       clause('expr')          { |e| ExpressionNode.new(e) }
-      clause('expr_comment')  { |e| CommentNode.new(e) }
       clause('expr_safe')     { |e| SafeExpressionNode.new(e) }
       clause('partial')       { |e| e }
     end
@@ -79,10 +79,6 @@ module FlavourSaver
 
     production(:expr) do
       clause('EXPRST expression_contents EXPRE') { |_,e,_| e }
-    end
-
-    production(:expr_comment) do
-      clause('EXPRST BANG COMMENT EXPRE') { |_,_,e,_| e }
     end
 
     production(:expr_safe) do

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -53,15 +53,10 @@ module FlavourSaver
     end
 
     production(:block_expression) do
-      clause('expr_bl_start template expr_else template expr_bl_end') { |e0,e1,_,e3,e2| BlockExpressionNodeWithElse.new([e0], e1,e2,e3) }
+      clause('expr_bl_start template EXPRELSE template expr_bl_end') { |e0,e1,_,e3,e2| BlockExpressionNodeWithElse.new([e0], e1,e2,e3) }
       clause('expr_bl_start template expr_bl_end') { |e0,e1,e2| BlockExpressionNode.new([e0],e1,e2) }
-      clause('expr_bl_inv_start template expr_else template expr_bl_end') { |e0,e1,_,e3,e2| BlockExpressionNodeWithElse.new([e0], e2,e2,e1) }
+      clause('expr_bl_inv_start template EXPRELSE template expr_bl_end') { |e0,e1,_,e3,e2| BlockExpressionNodeWithElse.new([e0], e2,e2,e1) }
       clause('expr_bl_inv_start template expr_bl_end') { |e0,e1,e2| BlockExpressionNodeWithElse.new([e0],TemplateNode.new([]),e2,e1) }
-    end
-
-    production(:expr_else) do
-      clause('EXPRST ELSE EXPRE') { |_,_,_| }
-      clause('EXPRSTHAT EXPRE') { |_,_| }
     end
 
     production(:expr) do

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -33,9 +33,9 @@ module FlavourSaver
     end
 
     production(:template_item) do
-      clause('OUT+') { |outputs| OutputNode.new(outputs.join) }
+      clause('OUT') { |output_string| OutputNode.new(output_string) }
       clause('expression') { |e| e }
-      clause('COMMENT') { |e| CommentNode.new(e) }
+      clause('COMMENT') { |comment_string| CommentNode.new(comment_string) }
     end
 
     production(:expression) do

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -46,10 +46,10 @@ module FlavourSaver
     end
 
     production(:partial) do
-      clause('EXPRSTGT WHITE? STRING EXPRE') { |_,_,e,_| PartialNode.new(e,[]) }
-      clause('EXPRSTGT WHITE? ident_or_literal EXPRE') { |_,_,e,_| PartialNode.new(e,[]) }
-      clause('EXPRSTGT WHITE? ident_or_literal WHITE? call EXPRE') { |_,_,e0,_,e1,_| PartialNode.new(e0,e1,nil) }
-      clause('EXPRSTGT WHITE? ident_or_literal WHITE? lit EXPRE') { |_,_,e0,_,e1,_| PartialNode.new(e0,[],e1) }
+      clause('EXPRSTGT STRING EXPRE') { |_,e,_| PartialNode.new(e,[]) }
+      clause('EXPRSTGT ident_or_literal EXPRE') { |_,e,_| PartialNode.new(e,[]) }
+      clause('EXPRSTGT ident_or_literal WHITE? call EXPRE') { |_,e0,_,e1,_| PartialNode.new(e0,e1,nil) }
+      clause('EXPRSTGT ident_or_literal WHITE? lit EXPRE') { |_,e0,_,e1,_| PartialNode.new(e0,[],e1) }
     end
 
     production(:block_expression) do
@@ -69,17 +69,17 @@ module FlavourSaver
     end
 
     production(:expr_bl_start) do
-      clause('EXPRSTHASH WHITE? IDENT EXPRE') { |_,_,e,_| push_block CallNode.new(e,[]) }
-      clause('EXPRSTHASH WHITE? IDENT WHITE arguments EXPRE') { |_,_,e,_,a,_| push_block CallNode.new(e,a) }
+      clause('EXPRSTHASH IDENT EXPRE') { |_,e,_| push_block CallNode.new(e,[]) }
+      clause('EXPRSTHASH IDENT WHITE arguments EXPRE') { |_,e,_,a,_| push_block CallNode.new(e,a) }
     end
 
     production(:expr_bl_inv_start) do
-      clause('EXPRSTHAT WHITE? IDENT EXPRE') { |_,_,e,_| push_block CallNode.new(e,[]) }
-      clause('EXPRSTHAT WHITE? IDENT WHITE arguments EXPRE') { |_,_,e,_,a,_| push_block CallNode.new(e,a) }
+      clause('EXPRSTHAT IDENT EXPRE') { |_,e,_| push_block CallNode.new(e,[]) }
+      clause('EXPRSTHAT IDENT WHITE arguments EXPRE') { |_,e,_,a,_| push_block CallNode.new(e,a) }
     end
 
     production(:expr_bl_end) do
-      clause('EXPRSTFWSL WHITE? IDENT EXPRE') { |_,_,e,_| pop_block CallNode.new(e,[]) }
+      clause('EXPRSTFWSL IDENT EXPRE') { |_,e,_| pop_block CallNode.new(e,[]) }
     end
 
     production(:expression_contents) do

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -28,24 +28,20 @@ module FlavourSaver
     right :EQ
 
     production(:template) do
-      clause('template_items') { |i| TemplateNode.new(i) }
+      clause('template_item+') { |i| TemplateNode.new(i) }
       clause('') { TemplateNode.new([]) }
     end
 
     # empty_list(:template_items, [:output, :expression], 'WHITE?')
-    production(:template_items) do
-      clause('template_item') { |i| [i] }
-      clause('template_items template_item') { |i0,i1| i0 << i1 }
-    end
+    # production(:template_items) do
+    #   clause('template_item+') { |i| i }
+    #   # clause('template_items template_item') { |i0,i1| i0 << i1 }
+    # end
 
     production(:template_item) do
-      clause('output') { |e| e }
+      clause('OUT') { |o| OutputNode.new(o) }
       clause('expression') { |e| e }
       clause('COMMENT') { |e| CommentNode.new(e) }
-    end
-
-    production(:output) do
-      clause('OUT') { |o| OutputNode.new(o) }
     end
 
     production(:expression) do
@@ -172,8 +168,8 @@ module FlavourSaver
     end
 
     production(:backtrack) do
-      clause('DOT DOT FWSL') { |_,_,_| 1 }
-      clause('backtrack DOT DOT FWSL') { |i,_,_,_| i += 1 }
+      clause('DOTDOTSLASH') { |_,| 1 }
+      clause('backtrack DOTDOTSLASH') { |i,_| i += 1 }
     end
 
     finalize

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -46,10 +46,10 @@ module FlavourSaver
     end
 
     production(:partial) do
-      clause('EXPRST WHITE? GT WHITE? STRING WHITE? EXPRE') { |_,_,_,_,e,_,_| PartialNode.new(e,[]) }
-      clause('EXPRST WHITE? GT WHITE? ident_or_literal WHITE? EXPRE') { |_,_,_,_,e,_,_| PartialNode.new(e,[]) }
-      clause('EXPRST WHITE? GT WHITE? ident_or_literal WHITE? call WHITE? EXPRE') { |_,_,_,_,e0,_,e1,_,_| PartialNode.new(e0,e1,nil) }
-      clause('EXPRST WHITE? GT WHITE? ident_or_literal WHITE? lit WHITE? EXPRE') { |_,_,_,_,e0,_,e1,_,_| PartialNode.new(e0,[],e1) }
+      clause('EXPRSTGT WHITE? STRING WHITE? EXPRE') { |_,_,e,_,_| PartialNode.new(e,[]) }
+      clause('EXPRSTGT WHITE? ident_or_literal WHITE? EXPRE') { |_,_,e,_,_| PartialNode.new(e,[]) }
+      clause('EXPRSTGT WHITE? ident_or_literal WHITE? call WHITE? EXPRE') { |_,_,e0,_,e1,_,_| PartialNode.new(e0,e1,nil) }
+      clause('EXPRSTGT WHITE? ident_or_literal WHITE? lit WHITE? EXPRE') { |_,_,e0,_,e1,_,_| PartialNode.new(e0,[],e1) }
     end
 
     production(:block_expression) do
@@ -61,7 +61,7 @@ module FlavourSaver
 
     production(:expr_else) do
       clause('EXPRST WHITE? ELSE WHITE? EXPRE') { |_,_,_,_,_| }
-      clause('EXPRST WHITE? HAT WHITE? EXPRE') { |_,_,_,_,_| }
+      clause('EXPRSTHAT WHITE? EXPRE') { |_,_,_| }
     end
 
     production(:expr) do
@@ -70,21 +70,21 @@ module FlavourSaver
 
     production(:expr_safe) do
       clause('TEXPRST expression_contents TEXPRE') { |_,e,_| e }
-      clause('EXPRST AMP expression_contents EXPRE') { |_,_,e,_| e }
+      clause('EXPRSTAMP expression_contents EXPRE') { |_,e,_| e }
     end
 
     production(:expr_bl_start) do
-      clause('EXPRST HASH WHITE? IDENT WHITE? EXPRE') { |_,_,_,e,_,_| push_block CallNode.new(e,[]) }
-      clause('EXPRST HASH WHITE? IDENT WHITE arguments WHITE? EXPRE') { |_,_,_,e,_,a,_,_| push_block CallNode.new(e,a) }
+      clause('EXPRSTHASH WHITE? IDENT WHITE? EXPRE') { |_,_,e,_,_| push_block CallNode.new(e,[]) }
+      clause('EXPRSTHASH WHITE? IDENT WHITE arguments WHITE? EXPRE') { |_,_,e,_,a,_,_| push_block CallNode.new(e,a) }
     end
 
     production(:expr_bl_inv_start) do
-      clause('EXPRST HAT WHITE? IDENT WHITE? EXPRE') { |_,_,_,e,_,_| push_block CallNode.new(e,[]) }
-      clause('EXPRST HAT WHITE? IDENT WHITE arguments WHITE? EXPRE') { |_,_,_,e,_,a,_,_| push_block CallNode.new(e,a) }
+      clause('EXPRSTHAT WHITE? IDENT WHITE? EXPRE') { |_,_,e,_,_| push_block CallNode.new(e,[]) }
+      clause('EXPRSTHAT WHITE? IDENT WHITE arguments WHITE? EXPRE') { |_,_,e,_,a,_,_| push_block CallNode.new(e,a) }
     end
 
     production(:expr_bl_end) do
-      clause('EXPRST FWSL WHITE? IDENT WHITE? EXPRE') { |_,_,_,e,_,_| pop_block CallNode.new(e,[]) }
+      clause('EXPRSTFWSL WHITE? IDENT WHITE? EXPRE') { |_,_,e,_,_| pop_block CallNode.new(e,[]) }
     end
 
     production(:expression_contents) do

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "0.3.6"
+  VERSION = "0.5.0-dokio"
 end

--- a/spec/acceptance/handlebars_qunit_spec.rb
+++ b/spec/acceptance/handlebars_qunit_spec.rb
@@ -766,7 +766,7 @@ describe FlavourSaver do
       let(:template) { "Message: {{hello \"world\" 12 true false}}" }
       before do
         FS.register_helper(:hello) do |param,times,bool1,bool2|
-          times = "NaN" unless times.is_a? Fixnum
+          times = "NaN" unless times.is_a? Integer
           bool1 = "NaB" unless bool1 == true
           bool2 = "NaB" unless bool2 == false
           "Hello #{param} #{times} times: #{bool1} #{bool2}"

--- a/spec/acceptance/handlebars_qunit_spec.rb
+++ b/spec/acceptance/handlebars_qunit_spec.rb
@@ -216,27 +216,27 @@ describe FlavourSaver do
     describe 'paths with hyphens' do
       describe '{{foo-bar}}' do
         let(:template) { "{{foo-bar}}" }
+        let(:context) { { :"foo-bar" => "baz" } }
 
         it 'paths can contain hyphens (-)' do
-          context.should_receive(:[]).with('foo-bar').and_return('baz')
           subject.should == 'baz'
         end
       end
 
       describe '{{foo.foo-bar}}' do
         let(:template) { "{{foo.foo-bar}}" }
+        let(:context) { { :foo => { :"foo-bar" => "baz" } } }
 
         it 'paths can contain hyphens (-)' do
-          context.stub_chain(:foo, :[]).with('foo-bar').and_return(proc { 'baz' })
           subject.should == 'baz'
         end
       end
 
       describe '{{foo/foo-bar}}' do
         let(:template) { "{{foo/foo-bar}}" }
+        let(:context) { { :foo => { :"foo-bar" => "baz" } } }
 
         it 'paths can contain hyphens (-)' do
-          context.stub_chain(:foo, :[]).with('foo-bar').and_return('baz')
           subject.should == 'baz'
         end
       end

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -207,5 +207,53 @@ describe FlavourSaver::Lexer do
         subject.map(&:value).should == ["asdf ", " alskjd } } alksdjf ", " asdf", nil]
       end
     end
+
+    describe 'Zero-length comment' do
+      subject { FlavourSaver::Lexer.lex "asdf {{!}} asdf" }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:OUT, :OUT, :EOS]
+      end
+
+      it 'has correct tokens' do
+        subject.map(&:value).should == ["asdf ", " asdf", nil]
+      end
+    end
+
+    describe 'Zero-length string' do
+      subject { FlavourSaver::Lexer.lex "asdf {{\"\"}} asdf" }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:OUT, :EXPRST, :STRING, :EXPRE, :OUT, :EOS]
+      end
+
+      it 'has correct tokens' do
+        subject.map(&:value).should == ["asdf ", nil, '', nil, " asdf", nil]
+      end
+    end
+
+    describe 'Zero-length single-quote string' do
+      subject { FlavourSaver::Lexer.lex "asdf {{''}} asdf" }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:OUT, :EXPRST, :S_STRING, :EXPRE, :OUT, :EOS]
+      end
+
+      it 'has correct tokens' do
+        subject.map(&:value).should == ["asdf ", nil, '', nil, " asdf", nil]
+      end
+    end
+
+    describe 'Zero-length literal' do
+      subject { FlavourSaver::Lexer.lex "asdf {{[]}} asdf" }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:OUT, :EXPRST, :LITERAL, :EXPRE, :OUT, :EOS]
+      end
+
+      it 'has correct tokens' do
+        subject.map(&:value).should == ["asdf ", nil, '', nil, " asdf", nil]
+      end
+    end
   end
 end

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -129,7 +129,7 @@ describe FlavourSaver::Lexer do
       subject { FlavourSaver::Lexer.lex "{{../foo}}" }
 
       it 'has tokens in the correct order' do
-        subject.map(&:type).should == [:EXPRST, :DOT, :DOT, :FWSL, :IDENT, :EXPRE, :EOS]
+        subject.map(&:type).should == [:EXPRST, :DOTDOTSLASH, :IDENT, :EXPRE, :EOS]
       end
     end
 
@@ -181,6 +181,18 @@ describe FlavourSaver::Lexer do
 
       it 'has tokens in the correct order' do
         subject.map(&:type).should == [:OUT,:EOS]
+      end
+    end
+
+    describe 'Mishmash of curlys etc' do
+      subject { FlavourSaver::Lexer.lex "asdf { asdf {} { { {{ hello }} }" }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :EXPRST, :WHITE, :IDENT, :WHITE, :EXPRE, :OUT, :EOS]
+      end
+
+      it 'has correct tokens' do
+        subject.map(&:value).should == ["asdf ", "{", " asdf ", "{", "} ", "{", " ", "{", " ", nil, nil, "hello", nil, nil, " }", nil]
       end
     end
   end

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -67,7 +67,7 @@ describe FlavourSaver::Lexer do
       subject { FlavourSaver::Lexer.lex '{{else}}' }
 
       it 'has tokens in the correct order' do
-        subject.map(&:type).should == [ :EXPRST, :ELSE, :EXPRE, :EOS ]
+        subject.map(&:type).should == [ :EXPRELSE, :EOS ]
       end
     end
 

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -188,11 +188,23 @@ describe FlavourSaver::Lexer do
       subject { FlavourSaver::Lexer.lex "asdf { asdf {} { { {{ hello }} }" }
 
       it 'has tokens in the correct order' do
-        subject.map(&:type).should == [:OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :OUT, :EXPRST, :WHITE, :IDENT, :WHITE, :EXPRE, :OUT, :EOS]
+        subject.map(&:type).should == [:OUT, :EXPRST, :WHITE, :IDENT, :WHITE, :EXPRE, :OUT, :EOS]
       end
 
       it 'has correct tokens' do
-        subject.map(&:value).should == ["asdf ", "{", " asdf ", "{", "} ", "{", " ", "{", " ", nil, nil, "hello", nil, nil, " }", nil]
+        subject.map(&:value).should == ["asdf { asdf {} { { ", nil, nil, "hello", nil, nil, " }", nil]
+      end
+    end
+
+    describe 'Complex comment' do
+      subject { FlavourSaver::Lexer.lex "asdf {{! alskjd } } alksdjf }} asdf" }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:OUT, :COMMENT, :OUT, :EOS]
+      end
+
+      it 'has correct tokens' do
+        subject.map(&:value).should == ["asdf ", " alskjd } } alksdjf ", " asdf", nil]
       end
     end
   end

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -121,7 +121,7 @@ describe FlavourSaver::Lexer do
       subject { FlavourSaver::Lexer.lex "{{! WAT}}" }
 
       it 'has tokens in the correct order' do
-        subject.map(&:type).should == [ :EXPRST, :BANG, :COMMENT, :EXPRE, :EOS ]
+        subject.map(&:type).should == [ :COMMENT, :EOS ]
       end
     end
 

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -147,9 +147,9 @@ describe FlavourSaver::Lexer do
       describe '{{#foo}}{{bar}}{{/foo}}' do
         it 'has tokens in the correct order' do
           subject.map(&:type).should == [
-            :EXPRST, :HASH, :IDENT, :EXPRE,
+            :EXPRSTHASH, :IDENT, :EXPRE,
             :EXPRST, :IDENT, :EXPRE,
-            :EXPRST, :FWSL, :IDENT, :EXPRE,
+            :EXPRSTFWSL, :IDENT, :EXPRE,
             :EOS
           ]
         end

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -188,11 +188,11 @@ describe FlavourSaver::Lexer do
       subject { FlavourSaver::Lexer.lex "asdf { asdf {} { { {{ hello }} }" }
 
       it 'has tokens in the correct order' do
-        subject.map(&:type).should == [:OUT, :EXPRST, :WHITE, :IDENT, :WHITE, :EXPRE, :OUT, :EOS]
+        subject.map(&:type).should == [:OUT, :EXPRST, :WHITE, :IDENT, :EXPRE, :OUT, :EOS]
       end
 
       it 'has correct tokens' do
-        subject.map(&:value).should == ["asdf { asdf {} { { ", nil, nil, "hello", nil, nil, " }", nil]
+        subject.map(&:value).should == ["asdf { asdf {} { { ", nil, nil, "hello", nil, " }", nil]
       end
     end
 

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -188,11 +188,11 @@ describe FlavourSaver::Lexer do
       subject { FlavourSaver::Lexer.lex "asdf { asdf {} { { {{ hello }} }" }
 
       it 'has tokens in the correct order' do
-        subject.map(&:type).should == [:OUT, :EXPRST, :WHITE, :IDENT, :EXPRE, :OUT, :EOS]
+        subject.map(&:type).should == [:OUT, :EXPRST, :IDENT, :EXPRE, :OUT, :EOS]
       end
 
       it 'has correct tokens' do
-        subject.map(&:value).should == ["asdf { asdf {} { { ", nil, nil, "hello", nil, " }", nil]
+        subject.map(&:value).should == ["asdf { asdf {} { { ", nil, "hello", nil, " }", nil]
       end
     end
 

--- a/spec/lib/flavour_saver/parser_spec.rb
+++ b/spec/lib/flavour_saver/parser_spec.rb
@@ -196,11 +196,15 @@ describe FlavourSaver::Parser do
     end
   end
 
-  describe '{{../foo}}' do
-    subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{../foo}}')) }
+  describe '{{../../foo}}' do
+    subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{../../foo}}')) }
 
     it 'returns a parent call node' do
       items.first.method.first.should be_a(FlavourSaver::ParentCallNode)
+    end
+
+    it 'has the right depth' do
+      items.first.method.first.depth.should == 2
     end
   end
 


### PR DESCRIPTION
This pull request:

- removes the weird patch Dokio did earlier to IDENT regex; it probably was causing infinite loops with input such as `{{ *` (i.e. when there's a character it doesn't understand, it would do a zero-length match, and then loop forever due to a bug in RLTK)
- sets the version number to something else
- merges IDENT and LITERAL lexing into one spot; the previous Dokio patch basically disabled the "magic literal" matcher -- we now just produce IDENTs even if it has dashes
- reorganises the Lexer so that everything can be evaluated in order, and enables `match_first`.
- simplifies the parser code by removing unnecessary productions (without changing output)
- removes reference to Fixnum (replaced with Integer), to shut Ruby up.
- changes the way comments are handled, `{{!` is now a special start token, there is no `BANG` output from the lexer.
- changes the way `../` is handled; it is now a single token
- changes the way whitespace is handled -- generally it is now merged with the starting `{{` and ending `}}` tokens, removing the need to mention it in the parser
- created a lot of special starting `{{#` etc tokens, so the matching is done in the lexer rather than the parser
- got rid of the block stack -- it was totally unnecessary; simplifying if/else processing a fair bit
- adds/improves a couple of tests
- adds editorconfig