### PR TITLE
Don't replace hash args with evaluated strings

### DIFF
--- a/lib/flavour_saver/runtime.rb
+++ b/lib/flavour_saver/runtime.rb
@@ -72,10 +72,7 @@ module FlavourSaver
       when CallNode
         evaluate_call(node)
       when Hash
-        node.each do |key,value|
-          node[key] = evaluate_argument(value)
-        end
-        node
+        node.transform_values { |v| evaluate_argument(v) }
       when CommentNode
         ''
       when PartialNode

--- a/spec/acceptance/handlebars_qunit_spec.rb
+++ b/spec/acceptance/handlebars_qunit_spec.rb
@@ -909,6 +909,15 @@ describe FlavourSaver do
       end
     end
 
+    describe 'each with thing with hash args' do # this is a specific bug; previously the second call with hash args would fail
+      let(:template) { "{{#each list}}{{#if thing='fish'}}{{this}}{{/if}}{{/each}}" }
+      let(:context) { { 'list' => [1,2,3] } }
+
+      it 'works correctly' do
+        expect(subject).to eq('123')
+      end
+    end
+
     describe 'log' do
       let(:template) { "{{log blah}}" }
       let(:log) { double(:log) }


### PR DESCRIPTION
When hash arguments are used in a loop, causing the node to be evaluated multiple times, the second time around it fails because the hash was modified to contain the evaluated nodes.

This returns a new hash instead.