### PR TITLE
Handle zero and negative numbers

### DIFF
--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -121,13 +121,13 @@ module FlavourSaver
       [ :BOOL, false ]
     end
 
+    rule /(0|-?[1-9][0-9]*(?:\.[0-9]+)?)/, :expression do |n|
+      [ :NUMBER, n ]
+    end
+
     rule /[A-Za-z_\-][A-Za-z0-9_\-]*/, :expression do |name|
       # this is a divergence from FlavourSaver by Dokio -- even the dashed things are treated as methods
       [ :IDENT, name ]
-    end
-
-    rule /([1-9][0-9]*(\.[0-9]+)?)/, :expression do |n|
-      [ :NUMBER, n ]
     end
 
     # COMMENT

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -255,5 +255,34 @@ describe FlavourSaver::Lexer do
         subject.map(&:value).should == ["asdf ", nil, '', nil, " asdf", nil]
       end
     end
+
+    context "literals" do
+      [
+        ["''", :S_STRING, ''],
+        ['""', :STRING, '' ],
+        ["'squote'", :S_STRING, 'squote'],
+        ['"dquote"', :STRING, 'dquote'],
+        ["0", :NUMBER, "0"],
+        ["1", :NUMBER, "1"],
+        ["12345", :NUMBER, "12345"],
+        ["-12345", :NUMBER, "-12345"],
+        ["1.5", :NUMBER, "1.5"],
+        ["-1.5", :NUMBER, "-1.5"],
+        ["true", :BOOL, true],
+        ["false", :BOOL, false],
+      ].each do |input, output_type, output_value|
+        context "#{input.inspect}" do
+          subject { FlavourSaver::Lexer.lex "asdf {{#{input}}} asdf" }
+
+          it 'has tokens in the correct order' do
+            subject.map(&:type).should == [:OUT, :EXPRST, output_type, :EXPRE, :OUT, :EOS]
+          end
+
+          it 'has correct tokens' do
+            subject.map(&:value).should == ["asdf ", nil, output_value, nil, " asdf", nil]
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
It didn't previously handle `0` and negative numbers.  Note that `-123` would previously have been interpreted as an identifier.  Hopefully this isn't a thing that's actually used anywhere.